### PR TITLE
Update Minerva repo location.

### DIFF
--- a/modules.ini
+++ b/modules.ini
@@ -100,7 +100,8 @@ license_spdx = CC-BY-SA-4.0
 [minerva]
 type = cpu
 human_name = Minerva
-src = https://github.com/lambdaconcept/minerva
+src = https://github.com/minerva-cpu/minerva
+branch = main
 contents = sources
 license = License :: OSI Approved :: BSD License
 license_spdx = BSD-2-Clause


### PR DESCRIPTION
This brings LiteX Minerva up to date with upstream Minerva and Amaranth. See https://github.com/litex-hub/pythondata-cpu-minerva/pull/1.