### PR TITLE
Add support for OpenRISC OMPIC

### DIFF
--- a/modules.ini
+++ b/modules.ini
@@ -211,3 +211,11 @@ src = https://github.com/enjoy-digital/tapcfg
 contents = data
 license = License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)
 license_spdx = LGPL-2.1-only
+
+[ompic]
+type = misc 
+human_name = ompic - device that handles IPI communication between cores in multi-core OpenRISC systems.
+src = https://github.com/openrisc/ompic
+contents = verilog
+license = License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
+license_spdx = MPL-2.0


### PR DESCRIPTION
Hello,

I would like to integrate OpenRISC OMPIC into LiteX.  This is needed to handle IPI communication between cores in multi-core OpenRISC systems within the LiteX ecosystem.

Thank You!